### PR TITLE
Fix README and hamburger naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 1. [プロジェクトの初期設定方法]
 2. [開発の基本的な流れ]
 
+## 前提条件
+
+- Node.js 20.10.0 以上がインストールされていること
+- パッケージマネージャーには **pnpm** を使用します。`corepack enable` したうえで
+  `corepack prepare pnpm@latest --activate` を実行してください。
+- Storybook のテストをローカルで動かす場合は `pnpm exec playwright install --with-deps` を実行し、ブラウザを取得してください。
+
 ## プロジェクトの初期設定方法
 [プロジェクトの初期設定方法]: #プロジェクトの初期設定方法
 

--- a/src/components/layouts/header/Header.tsx
+++ b/src/components/layouts/header/Header.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { sideBar } from "@styles/HeaderTv";
 import MenuItem from "@components/usecases/menu/listItem/MenuItem";
-import Humberger from "@components/uiParts/button/Humberger";
+import Hamburger from "@components/uiParts/button/Hamburger";
 import { Page } from "@constants/PageConstants";
 import { menuUnorderedList } from "@styles/MenuTv";
 
@@ -24,13 +24,13 @@ const Header: React.FC<HeaderProps> = ({ pageTitle }) => {
     <header className="mx-auto flex justify-between items-center py-3">
       <h1 className="text-2xl font-extrabold">{pageTitle}</h1>
 
-      <Humberger isOpen={openMenu} toggle={toggleMenuOpen} isInner={false} />
+      <Hamburger isOpen={openMenu} toggle={toggleMenuOpen} isInner={false} />
 
       {/* サイドバー */}
       <nav className={sideBar({ isOpen: openMenu })} tabIndex={openMenu ? 0 : -1}>
         <div className="flex justify-between items-center">
           <h2 className="text-xl font-bold my-4 text-left text-gray-900">Menu</h2>
-          <Humberger isOpen={openMenu} toggle={toggleMenuOpen} isInner={true} />
+          <Hamburger isOpen={openMenu} toggle={toggleMenuOpen} isInner={true} />
         </div>
 
         <ul className={menuUnorderedList()}>

--- a/src/components/uiParts/button/Hamburger.tsx
+++ b/src/components/uiParts/button/Hamburger.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
-import { humberger, humbergerLineTop, humbergerLineMiddle, humbergerLineBottom } from "@styles/HeaderTv";
+import { hamburger, hamburgerLineTop, hamburgerLineMiddle, hamburgerLineBottom } from "@styles/HeaderTv";
 
-interface HumbergerProps {
+interface HamburgerProps {
   isOpen?: boolean; // 外部で制御される開閉状態
   toggle?: () => void; // 外部から開閉を切り替える関数
   isInner: boolean;
 }
 
-const Humberger: React.FC<HumbergerProps> = ({ isOpen: externalIsOpen, toggle: externalToggle, isInner }) => {
+const Hamburger: React.FC<HamburgerProps> = ({ isOpen: externalIsOpen, toggle: externalToggle, isInner }) => {
   // 内部で開閉状態を管理するためのステート
   const [internalIsOpen, setInternalIsOpen] = useState(false);
 
@@ -21,15 +21,15 @@ const Humberger: React.FC<HumbergerProps> = ({ isOpen: externalIsOpen, toggle: e
         onClick={toggle}
         type="button"
         aria-description="menu"
-        className={humberger()}
+        className={hamburger()}
         tabIndex={!isInner ? 0 : isOpen ? 0 : -1}
       >
-        <div className={humbergerLineTop({ isOpen: isOpen })} />
-        <div className={humbergerLineMiddle({ isOpen: isOpen })} />
-        <div className={humbergerLineBottom({ isOpen: isOpen })} />
+        <div className={hamburgerLineTop({ isOpen: isOpen })} />
+        <div className={hamburgerLineMiddle({ isOpen: isOpen })} />
+        <div className={hamburgerLineBottom({ isOpen: isOpen })} />
       </button>
     </>
   );
 };
 
-export default Humberger;
+export default Hamburger;

--- a/src/styles/HeaderTv.ts
+++ b/src/styles/HeaderTv.ts
@@ -14,15 +14,15 @@ export const sideBar = tv({
   },
 });
 
-export const humberger = tv({
+export const hamburger = tv({
   base: "space-y-2 rounded-lg z-10 w-10 px-1 py-2 hover:bg-gray-200 flex flex-col justify-between items-center group",
 });
 
-export const humbergerLineBase = tv({
+export const hamburgerLineBase = tv({
   base: "w-4/5 h-0.5 bg-gray-400 duration-300 ease-in-out group-hover:bg-gray-700",
 });
-export const humbergerLineTop = tv({
-  extend: humbergerLineBase,
+export const hamburgerLineTop = tv({
+  extend: hamburgerLineBase,
   base: "transition-transform",
   variants: {
     isOpen: {
@@ -30,8 +30,8 @@ export const humbergerLineTop = tv({
     },
   },
 });
-export const humbergerLineMiddle = tv({
-  extend: humbergerLineBase,
+export const hamburgerLineMiddle = tv({
+  extend: hamburgerLineBase,
   base: "transition-opacity",
   variants: {
     isOpen: {
@@ -39,8 +39,8 @@ export const humbergerLineMiddle = tv({
     },
   },
 });
-export const humbergerLineBottom = tv({
-  extend: humbergerLineBase,
+export const hamburgerLineBottom = tv({
+  extend: hamburgerLineBase,
   base: "transition-transform",
   variants: {
     isOpen: {


### PR DESCRIPTION
## Summary
- README に Node.js / pnpm / Playwright の前提条件を追記
- Humberger コンポーネントを Hamburger に改名
- スタイル定義を hamburger 系に更新

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684bcc8e2c3c833384a03a0ad8a5b2bb